### PR TITLE
Support also capital lettter HTML syntax

### DIFF
--- a/syntaxes/es6-inline-html.json
+++ b/syntaxes/es6-inline-html.json
@@ -21,7 +21,7 @@
   },
   "patterns": [
     {
-      "begin": "(\\s?\\/\\*\\s?(html|template|inline-html|inline-template)\\s?\\*\\/\\s?)(`)",
+      "begin": "(\\s?\\/\\*\\s?(html|HTML|template|inline-html|inline-template)\\s?\\*\\/\\s?)(`)",
       "beginCaptures": {
         "1": {
           "name": "comment.block"


### PR DESCRIPTION
Prettier use this syntax. By this small change this extension gets compatible with prettier. Which is awesome!
```html
const text = /* HTML */ `
      <title>${title}</title>
`
```
https://github.com/prettier/prettier/issues/3548
https://prettier.io/blog/2018/11/07/1.15.0.html#html-template-literal-in-javascript