### PR TITLE
Add glsl support

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,24 @@
           "source.sql",
           "text.html"
         ],
+        "scopeName": "inline.es6-glsl",
+        "path": "./syntaxes/es6-inline-glsl.json",
+        "embeddedLanguages": {
+          "meta.embedded.glsl": "glsl"
+        }
+      },
+      {
+        "injectTo": [
+          "source.html",
+          "source.js",
+          "source.js.jsx",
+          "source.jsx",
+          "source.ts",
+          "source.tsx",
+          "source.vue",
+          "source.sql",
+          "text.html"
+        ],
         "scopeName": "inline.es6-xml",
         "path": "./syntaxes/es6-inline-xml.json",
         "embeddedLanguages": {

--- a/syntaxes/es6-inline-glsl.json
+++ b/syntaxes/es6-inline-glsl.json
@@ -1,0 +1,111 @@
+{
+  "fileTypes": [
+    "js",
+    "jsx",
+    "ts",
+    "tsx",
+    "html",
+    "vue",
+    "svelte"
+  ],
+  "injectionSelector": "L:source.js -comment -string, L:source.js -comment -string, L:source.jsx -comment -string,  L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string",
+  "injections": {
+    "L:source": {
+      "patterns": [
+        {
+          "match": "<",
+          "name": "invalid.illegal.bad-angle-bracket.html"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "begin": "(?i)(\\s?\\/\\*\\s?(glsl|inline-glsl)\\s?\\*\\/\\s?)(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "comment.block"
+        }
+      },
+      "end": "(`)",
+      "patterns": [
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "source.glsl"
+        },
+        {
+          "include": "inline.es6-htmlx#template"
+        }
+      ]
+    },
+    {
+      "begin": "(?i)((glsl|inline-glsl))(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "comment.block"
+        }
+      },
+      "end": "(`)",
+      "patterns": [
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "source.glsl"
+        },
+        {
+          "include": "inline.es6-htmlx#template"
+        },
+        {
+          "include": "string.quoted.other.template.js"
+        }
+      ]
+    },
+    {
+      "begin": "(?i)(?<=\\s|\\,|\\=|\\:|\\(|\\$\\()\\s{0,}(((\\/\\*)|(\\/\\/))\\s?(glsl|inline-glsl)[ ]{0,1000}\\*?\\/?)[ ]{0,1000}$",
+      "beginCaptures": {
+        "1": {
+          "name": "comment.line"
+        }
+      },
+      "end": "(`).*",
+      "patterns": [
+        {
+          "begin": "(\\G)",
+          "end": "(`)"
+        },
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "source.glsl"
+        }
+      ]
+    },
+    {
+      "begin": "(\\${)",
+      "end": "(})",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "entity.name.tag"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "source.js"
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.es6-glsl"
+}


### PR DESCRIPTION
This adds support for glsl highlighting for those with [slevesque.shader](https://marketplace.visualstudio.com/items?itemName=slevesque.shader) (or some other `source.glsl` provider) installed. I've only added the support for `/*glsl*/` and equivalent prefixes - I haven't touched the readme, version number etc.