### PR TITLE
Add php filetype compatibity

### DIFF
--- a/syntaxes/es6-inline-html.json
+++ b/syntaxes/es6-inline-html.json
@@ -6,7 +6,8 @@
     "tsx",
     "html",
     "vue",
-    "svelte"
+    "svelte",
+    "php"
   ],
   "injectionSelector": "L:source.js -comment -string, L:source.js -comment -string, L:source.jsx -comment -string,  L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string",
   "injections": {


### PR DESCRIPTION
Hi, I use this plugin regularly with my php project.
I'd like to add this small change to add support for the PHP file type.
I tend to add a lot `script` tags to pass variables to the front end so this would be nice it worked there too.
My eyeball test tells me it works with just that one line change in the commit I made.
![Screenshot from 2021-09-03 14-59-49](https://user-images.githubusercontent.com/84028499/132055025-39697884-daa9-48c6-94ba-a4222d991bb9.png)
