### PR TITLE
Remove link to (redundant) es6-string-css

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Adds syntax highlight support for code, placed in es6 multiline strings:
 - GLSL
 
 ## Community
-- [es6-string-css](https://github.com/bashmish/es6-string-css) - Highlight CSS in ES6 template literals
 - [python-string-sql](https://github.com/ptweir/python-string-sql) - Highlight SQL code in python multiline strings
 - [es6-string-javascript](https://github.com/Zjcompt/es6-string-javascript) - Highlight JS in multiline strings
 


### PR DESCRIPTION
Since v2.9.0 (854ca5498ffbe37f93fe13dd248021080af1322b) – issue #39 – the CSS language is built in to core: this makes the `es6-string-css` community link redundant.

I installed the `es6-string-css` extension while reading the README in the marketplace, assuming it was a useful suggestion (and missing the fact that CSS was already included in core). Earlier I was hacking at `es6-string-css` source and reloading my VS Code window to see the effects… but the changes I was iterating weren't manifesting. It took me a while to realise the reason was that `es6-string-html` was taking precedence 😅

I think it would be good to remove the suggestive mention from the README, since it's redundant and potentially confusing. Since these community plugins are essentially unintegrated patches, wouldn't it make sense to simply patch them in if desirable? There's already a lot of redundancy in the VS Code extensions marketplace, and any improvements / community suggestions ought to be centralised here IMO.

Thanks for the plugin BTW – I'm doing some remote procedure calls with an 'everything-in-JS' approach, and this really helps see code functionality at a glance 🙇‍♂️