### PR TITLE
fix regular expressions to allow whitespace before template tag

### DIFF
--- a/syntaxes/es6-inline-css.json
+++ b/syntaxes/es6-inline-css.json
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "begin": "(?i)((css|inline-css))(`)",
+      "begin": "(?i)(\\s*(css|inline-css))(`)",
       "beginCaptures": {
         "1": {
           "name": "comment.block"

--- a/syntaxes/es6-inline-glsl.json
+++ b/syntaxes/es6-inline-glsl.json
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "begin": "(?i)((glsl|inline-glsl))(`)",
+      "begin": "(?i)(\\s*(glsl|inline-glsl))(`)",
       "beginCaptures": {
         "1": {
           "name": "comment.block"

--- a/syntaxes/es6-inline-html.json
+++ b/syntaxes/es6-inline-html.json
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "begin": "(?i)((html|template|inline-html|inline-template))(`)",
+      "begin": "(?i)(\\s*(html|template|inline-html|inline-template))(`)",
       "beginCaptures": {
         "1": {
           "name": "comment.block"

--- a/syntaxes/es6-inline-sql.json
+++ b/syntaxes/es6-inline-sql.json
@@ -22,7 +22,7 @@
   },
   "patterns": [
     {
-      "begin": "(?i)(.?(sql))(`)",
+      "begin": "(?i)(\\s*(sql))(`)",
       "end": "(`)",
       "beginCaptures": {
         "1": {

--- a/syntaxes/es6-inline-xml.json
+++ b/syntaxes/es6-inline-xml.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "begin": "((xml|inline-xml))(`)",
+      "begin": "(?i)(\\s*(xml|inline-xml))(`)",
       "beginCaptures": {
         "1": {
           "name": "comment.block"


### PR DESCRIPTION
Every regular expression that matches the uncommented version of template tags other than the one for `sql` has a bug: any leading whitespace breaks syntax highlighting.

![Screenshot 2023-02-03 at 12 22 37 PM](https://user-images.githubusercontent.com/155164/216695186-982a0781-a7e7-4bd4-956c-eb8c4092882e.png)

This PR adds support for optional leading whitespace which fixes the issue.