### PR TITLE
fixes trailing highlighting with SQL cases

### DIFF
--- a/syntaxes/es6-inline-sql.json
+++ b/syntaxes/es6-inline-sql.json
@@ -22,7 +22,7 @@
   },
   "patterns": [
     {
-      "begin": "(?i)(\\s*(sql))(`)",
+      "begin": "(?i)\\b(\\w+\\.sql)\\s*(`)",
       "end": "(`)",
       "beginCaptures": {
         "1": {


### PR DESCRIPTION
closes #47 

This resolves #47 .

Fixes issues with trailing syntax in single-line "sql" syntax shown in issue. And also adds support for Prisma and other ORMs that use "xxxxx.sql" syntax.

![image](https://github.com/0x00000001A/es6-string-html/assets/15095818/4ef9aceb-7b3d-4bfe-acb0-be16b8396a2c)
