### PR TITLE
feat: add markdown support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,27 @@
 					"source.rescript",
 					"text.html"
 				],
+				"scopeName": "inline.es6-markdown",
+				"path": "./syntaxes/es6-inline-markdown.json",
+				"embeddedLanguages": {
+					"meta.embedded.markdown": "markdown"
+				}
+			},
+			{
+				"injectTo": [
+					"source.html",
+					"source.js",
+					"source.js.jsx",
+					"source.jsx",
+					"source.ts",
+					"source.tsx",
+					"source.vue",
+					"source.svelte",
+					"source.sql",
+					"source.css",
+					"source.rescript",
+					"text.html"
+				],
 				"scopeName": "inline.es6-css",
 				"path": "./syntaxes/es6-inline-css.json",
 				"embeddedLanguages": {

--- a/syntaxes/es6-inline-markdown.json
+++ b/syntaxes/es6-inline-markdown.json
@@ -1,0 +1,64 @@
+{
+  "fileTypes": [
+    "js",
+    "jsx",
+    "ts",
+    "tsx",
+    "html",
+    "vue",
+    "svelte",
+    "php",
+    "res"
+  ],
+  "injectionSelector": "L:source.js -comment -string, L:source.js -comment -string, L:source.jsx -comment -string,  L:source.js.jsx -comment -string, L:source.ts -comment -string, L:source.tsx -comment -string, L:source.rescript -comment -string",
+  "injections": {
+    "L:source": {
+      "patterns": [
+        {
+          "match": "<",
+          "name": "invalid.illegal.bad-angle-bracket.html"
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "begin": "(?i)(\\s?\\/\\*\\s?(md|markdown)\\s?\\*\\/\\s?)(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "comment.block"
+        },
+        "3": {
+          "name": "string.template.js"
+        }
+      },
+      "end": "(`)",
+      "endCaptures": {
+        "1": {
+          "name": "string.template.js"
+        }
+      },
+      "patterns": [
+        { "include": "text.html.markdown" }
+      ]
+    },
+    {
+      "begin": "(?i)(\\s*(md|markdown)`)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.template.js"
+        }
+      },
+      "end": "(`)",
+      "endCaptures": {
+        "1": {
+          "name": "string.template.js"
+        }
+      },
+      "patterns": [
+        { "include": "text.html.markdown" }
+      ]
+    }
+  ],
+  "scopeName": "inline.es6-markdown"
+}

--- a/tests/test.html
+++ b/tests/test.html
@@ -37,6 +37,9 @@
             <div attr="${test}asd${test}">Test</div>${elm}
         `;
 
+        variable = /* markdown */`this **is** ${test} _markdown_ `;
+        variable = /* md */`this **is** _markdown_`;
+
         variable = /*css*/`
         .className {
             color: red;
@@ -63,6 +66,16 @@
             const fn = (param) => param;
 
             const html = (param) => html`<div>Something</div>`;
+            const markdown = (param) => html`<div>Something</div>`;
+
+            fn(markdown`
+--- Hello
+hello **what is this**
+
+1. foo
+1. bar
+1. baz
+            `);
 
             fn(//html
             `<div>Something</div>${elm}`


### PR DESCRIPTION
Hi folks,

This patch adds markdown highlight. This works for inline markdown strings that multiline strings that don't have common indentation, like these:

```ts
const md = /* markdown */`
## Title

1. This is **important**
1. This might be _less important_
1. And absolutely unimportant
```

Let me know if this can be improved upon.

Thanks!

